### PR TITLE
update syntax

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,16 +1,16 @@
 resource "aws_iam_role" "this" {
-  name               = "${var.role_name}"
-  assume_role_policy = "${var.iam_role_policy_document_json}"
+  name               = var.role_name
+  assume_role_policy = var.iam_role_policy_document_json
 }
 
 resource "aws_iam_role_policy_attachment" "attachment" {
-  count      = "${var.policy_arns_count}"
-  role       = "${aws_iam_role.this.name}"
-  policy_arn = "${var.policy_arns[count.index]}"
+  count      = var.policy_arns_count
+  role       = aws_iam_role.this.name
+  policy_arn = var.policy_arns[count.index]
 }
 
 resource "aws_iam_instance_profile" "instance_profile" {
-  count = "${var.create_instance_role}"
-  name  = "${aws_iam_role.this.name}"
-  role  = "${aws_iam_role.this.name}"
+  count = var.create_instance_role
+  name  = aws_iam_role.this.name
+  role  = aws_iam_role.this.name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,7 +3,7 @@ variable "role_name" {
 }
 
 variable "iam_role_policy_document_json" {
-  type = "string"
+  type = string
 
   description = <<EOF
   Valid JSON Policy String
@@ -14,7 +14,7 @@ EOF
 }
 
 variable "policy_arns" {
-  type        = "list"
+  type        = list
   description = "List of policy arns to attach to this role"
   default     = []
 }


### PR DESCRIPTION
Thanks! I use this module.

I updated terraform to v0.12.17.
and get warning message like this.

```
Warning: Interpolation-only expressions are deprecated

  on .terraform/modules/iam_role_vpc_flow_log/anonymint-terraform-aws-iam-role-1f2956e/main.tf line 3, in resource "aws_iam_role" "this":
   3:   assume_role_policy = "${var.iam_role_policy_document_json}"

Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.
```

I would like to update syntax of this module.